### PR TITLE
Fix dynojet and smoothing UI refresh

### DIFF
--- a/fixed-tunemysubaru-v2.html
+++ b/fixed-tunemysubaru-v2.html
@@ -1871,7 +1871,8 @@
             
             smoothAcceleration(accelData) {
                 // Moving average smoothing for acceleration
-                const windowRadius = 3;
+                const radiusMap = [0, 2, 4, 6, 8, 10];
+                const windowRadius = radiusMap[Math.min(this.smoothingLevel, 5)];
                 const smoothed = [];
                 
                 for (let i = 0; i < accelData.length; i++) {
@@ -1900,7 +1901,8 @@
                 const sorted = [...results].sort((a, b) => a.rpm - b.rpm);
                 
                 // Determine bin size based on smoothing level
-                const binSizes = [0, 50, 40, 30, 25, 20];
+                // More aggressive binning for visible smoothing
+                const binSizes = [0, 50, 40, 30, 20, 15];
                 const binSize = binSizes[Math.min(this.smoothingLevel, 5)];
                 const bins = {};
                 
@@ -1930,7 +1932,8 @@
                 });
                 
                 // Apply additional smoothing based on level
-                const windowSizes = [0, 1, 2, 3, 4, 5];
+                // Larger window radius provides stronger smoothing effect
+                const windowSizes = [0, 2, 4, 6, 8, 10];
                 const windowRadius = windowSizes[Math.min(this.smoothingLevel, 5)];
                 
                 const smoothed = [];
@@ -2063,13 +2066,13 @@
                 // Chart checkboxes
                 ['showPower', 'showTorque', 'showBoost', 'showAFR', 'showSlip', 'hideBaseline', 'dynojetMode'].forEach(id => {
                     const checkbox = document.getElementById(id);
-                    if (checkbox) {
+                    if (checkbox && !checkbox.hasAttribute('data-initialized')) {
+                        checkbox.setAttribute('data-initialized', 'true');
                         checkbox.addEventListener('change', (e) => {
                             if (id === 'hideBaseline') {
                                 this.hideBaseline = e.target.checked;
                             } else if (id === 'dynojetMode') {
                                 this.dynojetMode = e.target.checked;
-                                // Recalculate with new mode
                                 if (this.analysisData) {
                                     this.recalculateWithDynojetMode();
                                 }
@@ -2077,19 +2080,21 @@
                                 this.chartOptions[id] = e.target.checked;
                             }
                             if (this.analysisData) {
-                                this.createDynoChart();
+                                this.refreshChart();
                             }
                         });
                     }
                 });
-                
+
                 // Smoothing control
                 const smoothingSelect = document.getElementById('smoothingLevel');
-                if (smoothingSelect) {
+                if (smoothingSelect && !smoothingSelect.hasAttribute('data-initialized')) {
+                    smoothingSelect.setAttribute('data-initialized', 'true');
                     smoothingSelect.addEventListener('change', (e) => {
                         const level = parseInt(e.target.value);
                         if (this.analysisData) {
                             this.recalculateWithSmoothing(level);
+                            this.refreshChart();
                         }
                     });
                 }
@@ -2268,7 +2273,10 @@
             
             calculateResults() {
                 // Create Power Calculator instance for user data
-                const calculator = new PowerCalculator(this.config);
+                const calculator = new PowerCalculator({
+                    ...this.config,
+                    dynojetMode: this.dynojetMode
+                });
                 
                 // Find pulls in user data
                 const pulls = calculator.findPulls(this.userLog.data);
@@ -2317,7 +2325,10 @@
                 // Process baseline data if available
                 if (this.baselineLog && this.baselineLog.data.length > 0) {
                     console.log('Processing baseline data...');
-                    const baselineCalculator = new PowerCalculator(this.config);
+                    const baselineCalculator = new PowerCalculator({
+                        ...this.config,
+                        dynojetMode: this.dynojetMode
+                    });
                     const baselinePulls = baselineCalculator.findPulls(this.baselineLog.data);
                     
                     if (baselinePulls.length > 0) {
@@ -2384,7 +2395,7 @@
                 }
                 
                 // Create chart
-                this.createDynoChart();
+                this.refreshChart();
             }
             
             recalculateWithSmoothing(level) {
@@ -2393,32 +2404,44 @@
                 // Update smoothing level
                 this.config.smoothingLevel = level;
                 
-                // Apply smoothing to USER data
-                const calculator = new PowerCalculator(this.config);
+                // Re-run power calculation with new smoothing level
+                const calculator = new PowerCalculator({
+                    ...this.config,
+                    dynojetMode: this.dynojetMode
+                });
+                const rawCurve = calculator.calculatePowerAndTorque(this.analysisData.pull);
                 let smoothedCurve;
-                
+
                 if (level === 0) {
                     // No smoothing - use raw data
-                    smoothedCurve = [...this.analysisData.rawPowerCurve];
+                    smoothedCurve = [...rawCurve];
                 } else {
-                    // Apply smoothing to existing raw data
-                    smoothedCurve = calculator.smoothResults(this.analysisData.rawPowerCurve);
+                    smoothedCurve = calculator.smoothResults(rawCurve);
                 }
+
+                // Store new raw curve
+                this.analysisData.rawPowerCurve = rawCurve;
                 
                 // Update displayed data
                 this.analysisData.powerCurve = smoothedCurve;
                 
                 // Apply smoothing to BASELINE data if it exists
                 if (this.baselineData && this.baselineData.rawPowerCurve) {
-                    const baselineCalculator = new PowerCalculator(this.config);
+                    const baselineCalculator = new PowerCalculator({
+                        ...this.config,
+                        dynojetMode: this.dynojetMode
+                    });
+
+                    const rawBaselineCurve = baselineCalculator.calculatePowerAndTorque(this.baselineData.pull);
                     let smoothedBaselineCurve;
-                    
+
                     if (level === 0) {
-                        smoothedBaselineCurve = [...this.baselineData.rawPowerCurve];
+                        smoothedBaselineCurve = [...rawBaselineCurve];
                     } else {
-                        smoothedBaselineCurve = baselineCalculator.smoothResults(this.baselineData.rawPowerCurve);
+                        smoothedBaselineCurve = baselineCalculator.smoothResults(rawBaselineCurve);
                     }
-                    
+
+                    this.baselineData.rawPowerCurve = rawBaselineCurve;
                     this.baselineData.powerCurve = smoothedBaselineCurve;
                 }
                 
@@ -2438,7 +2461,7 @@
                         `${currentPower} WHP / <span style="font-size: 1.8rem; opacity: 0.8;">${currentTorque} WTQ</span>`;
                     
                     // Redraw chart
-                    this.createDynoChart();
+                    this.refreshChart();
                 }
             }
             
@@ -2448,7 +2471,10 @@
                 
                 // Recalculate USER data
                 if (this.analysisData && this.analysisData.pull) {
-                    const calculator = new PowerCalculator(this.config);
+                    const calculator = new PowerCalculator({
+                        ...this.config,
+                        dynojetMode: this.dynojetMode
+                    });
                     const rawPowerCurve = calculator.calculatePowerAndTorque(this.analysisData.pull);
                     
                     if (rawPowerCurve && rawPowerCurve.length > 0) {
@@ -2482,7 +2508,10 @@
                 
                 // Recalculate BASELINE data
                 if (this.baselineData && this.baselineData.pull) {
-                    const baselineCalculator = new PowerCalculator(this.config);
+                    const baselineCalculator = new PowerCalculator({
+                        ...this.config,
+                        dynojetMode: this.dynojetMode
+                    });
                     const rawBaselineCurve = baselineCalculator.calculatePowerAndTorque(this.baselineData.pull);
                     
                     if (rawBaselineCurve && rawBaselineCurve.length > 0) {
@@ -2494,7 +2523,7 @@
                 }
                 
                 // Redraw chart
-                this.createDynoChart();
+                this.refreshChart();
             }
             
             analyzeForIssues() {
@@ -2646,10 +2675,14 @@
                 if (this.config.safety === 'conservative') boost -= 1;
                 if (this.config.safety === 'aggressive') boost += 2;
                 if (this.config.safety === 'yolo') boost += 3;
-                
+
                 return boost;
             }
-            
+
+            refreshChart() {
+                requestAnimationFrame(() => this.createDynoChart());
+            }
+
             createDynoChart() {
                 const chartContainer = document.getElementById('dynoChart');
                 


### PR DESCRIPTION
## Summary
- reinitialize chart controls just once and refresh dynamically
- add `refreshChart()` helper using `requestAnimationFrame`
- call `refreshChart()` after dynojet or smoothing recalculations so the chart updates immediately

## Testing
- `node -v`
- `node app.js` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_685bf6652fe083209d38a10ec61282f8