### PR TITLE
Fix dyno chart refresh logic

### DIFF
--- a/fixed-tunemysubaru-v2.html
+++ b/fixed-tunemysubaru-v2.html
@@ -2393,6 +2393,8 @@
                 
                 // Create chart
                 this.createDynoChart();
+                // Ensure redraw in some browsers
+                this.forceChartRefresh();
             }
             
             recalculateWithSmoothing(level) {
@@ -2456,6 +2458,8 @@
                     chartContainer.style.display = 'block';
 
                     this.createDynoChart();
+                    // Ensure redraw in some browsers
+                    this.forceChartRefresh();
                 }
             }
             
@@ -2523,6 +2527,8 @@
                 chartContainer.style.display = 'block';
 
                 this.createDynoChart();
+                // Ensure redraw in some browsers
+                this.forceChartRefresh();
             }
             
             analyzeForIssues() {


### PR DESCRIPTION
## Summary
- ensure the dyno chart redraws after recalculating results

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_685c1abd18008320b3e7bf1f06552c2a