### PR TITLE
Fix dyno chart refresh logic

### DIFF
--- a/fixed-tunemysubaru-v2.html
+++ b/fixed-tunemysubaru-v2.html
@@ -2449,12 +2449,8 @@
                     powerCard.querySelector('.analysis-value').innerHTML =
                         `${currentPower} WHP / <span style="font-size: 1.8rem; opacity: 0.8;">${currentTorque} WTQ</span>`;
 
-                    // Force immediate chart redraw
+                    // Refresh chart immediately
                     const chartContainer = document.getElementById('dynoChart');
-                    chartContainer.style.display = 'none';
-                    chartContainer.offsetHeight;
-                    chartContainer.style.display = 'block';
-
                     this.createDynoChart();
                 }
             }
@@ -2518,10 +2514,6 @@
                 
                 // Force immediate chart redraw
                 const chartContainer = document.getElementById('dynoChart');
-                chartContainer.style.display = 'none';
-                chartContainer.offsetHeight;
-                chartContainer.style.display = 'block';
-
                 this.createDynoChart();
             }
             
@@ -2691,23 +2683,13 @@
                     return;
                 }
 
-                // Clear and force complete redraw
+                // Clear previous chart
                 chartContainer.innerHTML = '';
 
-                // Use requestAnimationFrame to ensure the clear happens first
-                requestAnimationFrame(() => {
-                    // Create premium SVG chart with timestamp to prevent caching
-                    const chartHTML = this.createPremiumChart();
-                    chartContainer.innerHTML = chartHTML;
-                });
-            }
-
-            forceChartRefresh() {
-                const chartContainer = document.getElementById('dynoChart');
-                if (chartContainer) {
-                    // Force immediate redraw without requestAnimationFrame
-                    this.createDynoChart();
-                }
+                // Create premium SVG chart and append timestamp to bust cache
+                const chartHTML = this.createPremiumChart();
+                const timestamp = Date.now();
+                chartContainer.innerHTML = `${chartHTML}<span style="display:none">${timestamp}</span>`;
             }
 
             createPremiumChart() {


### PR DESCRIPTION
## Summary
- refresh dyno chart markup synchronously
- remove display toggles when recalculating results
- ensure final newline in `fixed-tunemysubaru-v2.html`

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_685c1abd18008320b3e7bf1f06552c2a