### PR TITLE
Fix site naming and stats

### DIFF
--- a/getmtuned-dyno.html
+++ b/getmtuned-dyno.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>TuneMySubaru | Precision Performance Engineering</title>
+    <title>GetMtuned | Precision Performance Engineering</title>
     
     <style>
         @import url('https://fonts.googleapis.com/css2?family=Orbitron:wght@400;500;600;700;800;900&family=Rajdhani:wght@300;400;500;600;700&family=Michroma&display=swap');
@@ -1121,7 +1121,7 @@
                 <span>🏁</span> Cobb Protuner Since 2008
             </div>
             <h1 class="hero-title">
-                Virtual Dyno <span class="accent">Perfected</span>
+                Get M-tuned's <span class="accent">Dyno</span>
             </h1>
             <p class="hero-subtitle">
                 Upload your datalog. Get laboratory-grade power analysis. 
@@ -1136,11 +1136,11 @@
                 <div class="stat-label">Accuracy</div>
             </div>
             <div class="stat">
-                <div class="stat-value">15K+</div>
-                <div class="stat-label">Dynos Run</div>
+                <div class="stat-value">Dyno</div>
+                <div class="stat-label">Verified</div>
             </div>
             <div class="stat">
-                <div class="stat-value">50Hz</div>
+                <div class="stat-value">Instant</div>
                 <div class="stat-label">Processing</div>
             </div>
             <div class="stat">
@@ -3323,7 +3323,7 @@
                 ctx.font = 'italic 14px Arial';
                 ctx.textAlign = 'center';
                 ctx.fillStyle = '#a3a3a3';
-                ctx.fillText('M-TUNED Performance Engineering | RPM-Based Virtual Dyno System', canvas.width / 2, canvas.height - 40);
+                ctx.fillText('GetMtuned Performance Engineering | RPM-Based Dyno System', canvas.width / 2, canvas.height - 40);
                 
                 // Download
                 canvas.toBlob((blob) => {

--- a/index.html
+++ b/index.html
@@ -2,9 +2,9 @@
 <html lang="en">
 <head>
     <meta charset="UTF-8">
-    <meta http-equiv="refresh" content="0; url=fixed-tunemysubaru-v2.html">
-    <link rel="canonical" href="fixed-tunemysubaru-v2.html">
-    <title>TuneMySubaru Redirect</title>
+    <meta http-equiv="refresh" content="0; url=getmtuned-dyno.html">
+    <link rel="canonical" href="getmtuned-dyno.html">
+    <title>GetMtuned Dyno</title>
 </head>
 <body>
     <p>If you are not redirected automatically, <a href="portal.html">click here</a>.</p>

--- a/portal.html
+++ b/portal.html
@@ -164,9 +164,9 @@
     <div class="bg-pattern"></div>
     <nav>
         <div class="nav-container">
-            <a href="tunemysubaru-homepage.html" class="logo">M-TUNED</a>
+            <a href="getmtuned-dyno.html" class="logo">GETMTUNED</a>
             <div class="nav-links">
-                <a href="tunemysubaru-homepage.html" class="nav-link">Home</a>
+                <a href="getmtuned-dyno.html" class="nav-link">Home</a>
             </div>
         </div>
     </nav>


### PR DESCRIPTION
## Summary
- rename main page to `getmtuned-dyno.html`
- update index redirect and portal links
- change hero heading and stat bar to match GetMtuned branding

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685c5ebce5bc8320baacaa27f909106d